### PR TITLE
Use Basic Auth credentials in Cypress test

### DIFF
--- a/test/e2e/integration/protected.spec.js
+++ b/test/e2e/integration/protected.spec.js
@@ -1,6 +1,11 @@
 context(`Demo (${Cypress.config().baseUrl})`, () => {
     beforeEach(() => {
-      cy.visit('/protected/')
+      cy.visit('/protected/', {
+        auth: {
+          username: 'demo',
+          password: 'tryme'
+        }
+      })
     })
   
     describe('Home page', () => {


### PR DESCRIPTION
https://docs.cypress.io/api/commands/visit.html#Add-basic-auth-headers